### PR TITLE
Corrected the link to All category option

### DIFF
--- a/_includes/page/explore.html
+++ b/_includes/page/explore.html
@@ -5,6 +5,6 @@
         {% for category in site.data.categories %}
             <li class="categories__item"><a href="{{ '/categories/' | append: category.slug | prepend: site.baseurl }}">{{ category.name }}</a></li>
         {% endfor %}
-        <li class="categories__item"><a href="/">All</a></li>
+		<li class="categories__item"><a href="{{ '/' | prepend: site.baseurl }}">All</a></li>
     </ul>
 </div>


### PR DESCRIPTION
So basically if a person clicked the 'All' category in the bottom it completely ignored the baseurl, and takes them to '/'. Since I am using it at anshulchauhan.com/blog/ , so when I press 'All' it took me to anshulchauhan.com but instead it should've taken me to anshulchauhan.com/blog/ because 'All' my posts will be there only. So I just made a small edit, and it seems to have benn fixint it. It's my first pull request ever, so i don't really know how to do this. So ignore my naiveness.
