### PR TITLE
SEO: sitemap.xml and robots.txt added.

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,8 @@
 ---
 layout: page
 title: 404
+sitemap:
+  exclude: 'yes'
 ---
 
 <h2 class="go-home">

--- a/css/main.scss
+++ b/css/main.scss
@@ -1,5 +1,7 @@
 ---
 # Only the main Sass file needs front matter (the dashes are enough)
+sitemap:
+  exclude: 'yes'
 ---
 @charset "utf-8";
 

--- a/feed.xml
+++ b/feed.xml
@@ -1,5 +1,7 @@
 ---
 layout: null
+sitemap:
+  exclude: 'yes'
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">

--- a/index.html
+++ b/index.html
@@ -2,6 +2,8 @@
 layout: page
 title: Blog
 subtitle: Hitchhiker's guid to web development
+sitemap:
+  priority: 0.9
 ---
 
 <ul class="list-posts">

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,9 @@
+---
+layout: null
+sitemap:
+  exclude: 'yes'
+---
+User-agent: *
+Disallow:
+
+Sitemap: {{ site.url }}/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,56 @@
+---
+layout: null
+sitemap:
+  exclude: 'yes'
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {% for post in site.posts %}
+    {% unless post.published == false %}
+    <url>
+      <loc>{{ site.url }}{{ post.url }}/</loc>
+      {% if post.sitemap.lastmod %}
+        <lastmod>{{ post.sitemap.lastmod | date: "%Y-%m-%d" }}</lastmod>
+      {% elsif post.date %}
+        <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
+      {% else %}
+        <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
+      {% endif %}
+      {% if post.sitemap.changefreq %}
+        <changefreq>{{ post.sitemap.changefreq }}</changefreq>
+      {% else %}
+        <changefreq>monthly</changefreq>
+      {% endif %}
+      {% if post.sitemap.priority %}
+        <priority>{{ post.sitemap.priority }}</priority>
+      {% else %}
+        <priority>0.7</priority>
+      {% endif %}
+    </url>
+    {% endunless %}
+  {% endfor %}
+  {% for page in site.pages %}
+    {% unless page.sitemap.exclude == "yes" %}
+    <url>
+      <loc>{{ site.url }}{{ page.url | remove: "index.html" }}</loc>
+      {% if page.sitemap.lastmod %}
+        <lastmod>{{ page.sitemap.lastmod | date: "%Y-%m-%d" }}</lastmod>
+      {% elsif page.date %}
+        <lastmod>{{ page.date | date_to_xmlschema }}</lastmod>
+      {% else %}
+        <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
+      {% endif %}
+      {% if page.sitemap.changefreq %}
+        <changefreq>{{ page.sitemap.changefreq }}</changefreq>
+      {% else %}
+        <changefreq>monthly</changefreq>
+      {% endif %}
+      {% if page.sitemap.priority %}
+        <priority>{{ page.sitemap.priority }}</priority>
+      {% else %}
+        <priority>0.5</priority>
+      {% endif %}
+    </url>
+    {% endunless %}
+  {% endfor %}
+</urlset>


### PR DESCRIPTION
sitemap.xml format is as follows: [sitemaps.org - Protocol](http://www.sitemaps.org/protocol.html)
## How it works

Code in sitemap.xml loops through all `site.posts` and `site.pages` and checks parameters inside `sitemap` array in YAML front matter. `sitemap` is not mandatory because all parameters will be set up to defaults if they are not explicitly defined (e.g. `<lastmod>` will be set up to the `site.time` value).
### Excluding 404.html, feed, etc

Some of the pages does not contain interesting content and we don't want them in our sitemap. To exclude such pages we put `sitemap: exclude: 'yes'`.
### Priorities

[Protocol](http://www.sitemaps.org/protocol.html) suggests to use 0.5 as default priority. This provides crawlers with meta-info on how we prioritize our content. We'll set pages priority to 0.5, posts priority to 0.7 and index.html priority to 0.9 (because it's our main page). This also could be set up manually in the front matter.
## robots.txt

[Reference](http://www.robotstxt.org/robotstxt.html)

`User-agent: *` - allows all kinds of crawlers to parse our content.
`Disallow:` - all pages are allowed to index.
`Sitemap: {{ site.url }}/sitemap.xml` - points crawlers to our sitemap.xml
