### PR TITLE
Exclude README.md and README.html from generated site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,5 +17,8 @@ author:
 
 # google_analytics: 'UA-XXXXXXXX-X'
 
+# Handling Reading
+exclude: ["README.md", "README.html"]
+
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
By default Jekyll places all files from its root directory into generated site. This leads to situation that after starting Jekyll development server both README files are available:
- localhost:4000/README.html
- localhost:4000/README.md

We can modify this behavior by adding `exclude` variable into `_config.yml`.
