### PR TITLE
PR proposal to Issue #11 (possibility to set up highlight.js style in _config.yml)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,8 +17,13 @@ author:
 
 # google_analytics: 'UA-XXXXXXXX-X'
 
+# Syntax highlighting
+highlightstyle: ''
+styles: [agate, androidstudio, arta, asceti, atelier-cave.dark, atelier-cave.light, atelier-dune.dark, atelier-dune.light, atelier-estuary.dark, atelier-estuary.light, atelier-forest.dark, atelier-forest.light, atelier-heath.dark, atelier-heath.light, atelier-lakeside.dark, atelier-lakeside.light, atelier-plateau.dark, atelier-plateau.light, atelier-savanna.dark, atelier-savanna.light, atelier-seaside.dark, atelier-seaside.light, atelier-sulphurpool.dark, atelier-sulphurpool.light, brown_paper, codepen-embed, color-brewer, dark, darkula, default, docco, far, foundation, github, github-gist, googlecode, grayscale, hopscotch, hybrid, idea, ir_black, kimbie.dark, kimbie.light, magula, mono-blue, monokai, monokai_sublime, obsidian, paraiso.dark, paraiso.light, pojoaque, railscast, rainbow, school_book, solarized_dark, solarized_light, styles_list.txt, sunburst, tomorrow, tomorrow-night-blue, tomorrow-night-bright, tomorrow-night, tomorrow-night-eightie, v, xcode, zenburn]
+
 # Handling Reading
 exclude: ["README.md", "README.html"]
 
 # Build settings
+highlighter: null
 markdown: kramdown

--- a/_includes/externals/styling.html
+++ b/_includes/externals/styling.html
@@ -1,5 +1,9 @@
 <link href='http://fonts.googleapis.com/css?family=Inconsolata:400,700' rel='stylesheet' type='text/css'>
 <link rel="stylesheet" href="{{ "/assets/vendor/normalize-css/normalize.css" | prepend: site.baseurl }}">
 <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
-<link rel="stylesheet" href="{{ "/assets/vendor/highlight/styles/solarized_dark.css" | prepend: site.baseurl }}">
+{% if site.styles contains site.highlightstyle %}
+  <link rel="stylesheet" href="{{ site.baseurl }}/assets/vendor/highlight/styles/{{ site.highlightstyle }}.css">
+{% else %}
+  <link rel="stylesheet" href="{{ site.baseurl }}/assets/vendor/highlight/styles/solarized_dark.css">
+{% endif %}
 <link rel="stylesheet" href="{{ "/assets/vendor/font-awesome/css/font-awesome.css" | prepend: site.baseurl }}">


### PR DESCRIPTION
By specifying `highlightstyle` option in `_config.yml` it is possible to choose syntax highlighting style according to CSS styles located in `/assets/vendor/highlight/styles`.

`if else` block inside `styling.html` checks whether specified style is available in `site.styles` (lists all CSS styles) and if Ok, loads it. If `highlightstyle` is empty or invalid value, it defaults to `solarized_dark`. This prevents from unproper input values or styles which are not actually available.

I also placed `highlighter: null` in `_config.yml` to explicitly show that external highlighter (highlight.js) is in use. By default, Jekyll 3 uses [Rouge](http://rouge.jneen.net/).
